### PR TITLE
商品出品機能２

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,7 @@ class ItemsController < ApplicationController
 
   # トップページ表示
   def index
-    @items = Item.order(created_at: :desc)
+   # @items = Item.order(created_at: :desc)
   end
 
   def show

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,9 +11,6 @@ class Item < ApplicationRecord
   belongs_to_active_hash :delivery_time
 
   with_options presence: true do
-    validates :title
-    validates :product_contents
-    validates :image
     validates :price
   end
 
@@ -34,8 +31,10 @@ class Item < ApplicationRecord
   end
 
   # 価格（300~9,999,999、整数のみ）
-  validates :price, numericality: { only_integer: true, message: 'is not a number' }
-  validates :price,
-            numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999,
-                            message: 'must be between ¥300 and ¥9,999,999' }
+  with_options presence: true do
+  validates :price, numericality: { only_integer: true, message: 'must be an integer' }
+  validates :price, numericality: { greater_than_or_equal_to: 300,
+                                    less_than_or_equal_to: 9_999_999,
+                                    message: 'must be between ¥300 and ¥9,999,999' }
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,10 +10,6 @@ class Item < ApplicationRecord
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :delivery_time
 
-  with_options presence: true do
-    validates :price
-  end
-
   # 画像１枚添付
   validates :image, presence: true
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -17,11 +17,13 @@
       <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
     </div>
   </div>
-  
+  <%# /画面上部の「人生を変えるフリマアプリ」帯部分  %>
+
   <%# FURIMAが選ばれる3つの理由部分 %>
   <div class='select-reason-contents'>
     <h2 class='title'>
-      FURIMAが選ばれる3つの理由</h2>
+      FURIMAが選ばれる3つの理由
+    </h2>
     <ul class='reason-lists'>
       <li class='list'>
         <%= image_tag "furima-intro01.png", class:"list-pict" %>
@@ -38,7 +40,9 @@
         <%= image_tag "furima-intro02.png", class:"list-pict" %>
         <span class='reason-list-number'>2</span>
         <h3 class='reason-list-text'>
-          <span class='reason-list-blue-text'>シンプル</span>で使いやすい</h3>
+          <span class='reason-list-blue-text'>シンプル</span>
+          で使いやすい
+        </h3>
         <p class='reason-list-description'>
           めんどくさい入力は必要なく、検索も購入もスムーズ！
         </p>
@@ -51,10 +55,12 @@
           <span class='reason-list-blue-text'>業界最安</span>
         </h3>
         <p class='reason-list-description'>
-          10%でお得に出品&購入！</p>
+          10%でお得に出品&購入！
+        </p>
       </li>
     </ul>
   </div>
+  <%# /FURIMAが選ばれる3つの理由部分 %>
 
   <%# 画面中央の「会員数日本一位」帯部分 %>
   <div class='ad-contents'>
@@ -75,6 +81,7 @@
       <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
     </div>
   </div>
+  <%# /画面中央の「会員数日本一位」帯部分 %>
 
   <%# FURIMAの特徴 %>
   <div class='feature-contents'>
@@ -119,58 +126,63 @@
     <div class="subtitle" >
       新規投稿商品
     </div>
-
     <ul class='item-lists'>
-      <% if @items.any? %>
-        <% @items.each do |item| %>
-          <li class='list'>
-            <%= link_to item_path(item) do %>
-              <div class='item-img-content'>
-                <% if item.image.attached? %>
-                  <%= image_tag item.image, class: "item-img" %>
-                <% else %>  
-                  <%= image_tag "item-sample.png", class: "item-img" %>
-                <% end %>
-              
-                <%# Sold Out を画像上に重ねる %>
-                <%#div class='sold-out'>Sold Out!!</div>
-                <% end %>
-              </div>
 
-          <div class='item-info'>
-            <h3 class='item-name'><%= item.title %></h3>
-            <div class='item-price'>
-              <span>
-                <%= item.price %>円<br>
-                <%= item.category.name %>
-                <%= item.condition.name %> /
-                <%= item.shipping_method.name %>
-                </span>
-              </div>
-            </div>
-          <% end %>
-        </li>
-      <% end %>
-    <% else %>
+      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to '#' do %>
-          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-          <div class='item-info'>
-            <h3 class='item-name'>商品を出品してね！</h3>
-            <div class='item-price'>
-              <span>99999999円<br>(税込み)</span>
+        <%= link_to "#" do %>
+        <div class='item-img-content'>
+          <%= image_tag "item-sample.png", class: "item-img" %>
+
+          <%# 商品が売れていればsold outを表示しましょう %>
+          <div class='sold-out'>
+            <span>Sold Out!!</span>
+          </div>
+          <%# //商品が売れていればsold outを表示しましょう %>
+
+        </div>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            <%= "商品名" %>
+          </h3>
+          <div class='item-price'>
+            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
             </div>
           </div>
+        </div>
         <% end %>
       </li>
-    <% end %>
-  </ul>
-</div>
+      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-
-  <%#//商品がない場合は以下のダミー商品が表示 %>
+      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <%# 商品がある場合は表示されないようにしましょう %>
+      <li class='list'>
+        <%= link_to '#' do %>
+        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            商品を出品してね！
+          </h3>
+          <div class='item-price'>
+            <span>99999999円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+        <% end %>
+      </li>
+      <%# //商品がある場合は表示されないようにしましょう %>
+      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    </ul>
+  </div>
   <%# /商品一覧 %>
-<%= link_to new_item_path, class: 'purchase-btn' do %>
+</div>
+<%= link_to('#', class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
 <% end %>

--- a/db/migrate/20250907121219_create_items.rb
+++ b/db/migrate/20250907121219_create_items.rb
@@ -1,15 +1,15 @@
 class CreateItems < ActiveRecord::Migration[7.1]
   def change
     create_table :items do |t|
-      t.string :title
-      t.text :product_contents
-      t.integer :category_id
-      t.integer :condition_id
-      t.integer :shipping_method_id
-      t.integer :prefecture_id
-      t.integer :delivery_time_id
-      t.integer :price
-      t.references :user, null: false, foreign_key: true
+      t.string  :title,              null: false
+      t.text    :product_contents,   null: false
+      t.integer :category_id,        null: false
+      t.integer :condition_id,       null: false
+      t.integer :shipping_method_id, null: false
+      t.integer :prefecture_id,      null: false
+      t.integer :delivery_time_id,   null: false
+      t.integer :price,              null: false
+      t.references :user,            null: false, foreign_key: true
 
       t.timestamps
     end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Item, type: :model do
       it '価格が空では出品できない' do
         item.price = ''
         item.valid?
-        expect(item.errors.full_messages).to include('Price is not a number')
+        expect(item.errors.full_messages).to include("Price can't be blank")
       end
 
       it '価格が300円未満では出品できない' do
@@ -80,7 +80,7 @@ RSpec.describe Item, type: :model do
       it '価格が全角数字では出品できない' do
         item.price = '３００'
         item.valid?
-        expect(item.errors.full_messages).to include('Price is not a number')
+        expect(item.errors.full_messages).to include('Price must be an integer')
       end
 
       it 'ユーザーが紐付いていないと出品できない' do


### PR DESCRIPTION
最終課題の「商品出品機能」を実装いたしました。
昨日、同様のプルリクエストを作成し修正レビューをいただいておりましたが、誤ってマージしてしまいました。
メンターの荘林さんにご相談させていただき、新しく別にプルリクエストを作成させていただきましたので、申し訳ございませんがよろしくお願いいたします。

# What
フリマアプリに商品を出品できる機能を実装しました。

# Why
ユーザーが商品を出品できるようにするためです。

■Gyao

ログイン状態の場合は、商品出品ページへ遷移できる動画
https://gyazo.com/c33c5b255980bb8dd32e6e985c255553

価格が入力されると同時に、販売手数料と販売利益が表示される動画
https://gyazo.com/a7420b855606521cfc8b1a9d8db08a98

必要な情報を適切に入力して「出品する」ボタンを押すと、商品情報がデータベースに保存される動画
https://gyazo.com/d0e6d8246516d620359b0d4b6496c84e

入力に問題がある状態で「出品する」ボタンが押された場合、情報は保存されず、出品ページに戻りエラーメッセージが表示される動画
https://gyazo.com/5b8554b575da7f597d15c354fb01faf3

ログアウト状態の場合は、商品出品ページへ遷移しようとすると、ログインページへ遷移する動画
https://gyazo.com/e8017d603b0ff489ab91ce19154bc6a9

テスト結果の画像
https://gyazo.com/44a34906dd529b85b5a0cdc9fa03bbd6

よろしくお願いいたします。

◆１回目の修正か所
・マークダウンを適用しましょう
・バリデーションが重複しているため必要なコードのみ残しましょう
・20250907121219_create_items.rb　null: falseが付与されていないカラムがあるため、要件に従い、null: false を付与する
